### PR TITLE
Added functionality to check effect of nucleotide substitution on amino acid sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ gemucator is short for "Genbank Mutation Locator". It is a simple Python3 class 
 
 The package comes with a simple script called `gemucator-run.py` that shows how it works. All these examples are for TB.
 
-First, let's see what happens when we give it an amino acid mutation (which has to be, be definition, in the coding sequence of a gene).
+First, let's see what happens when we give it an amino acid mutation (which has to be, be definition, in the coding sequence of a gene). Note - the below positions are 0-indexed, which is the normal python way of doing things. To convert this to a genome position for e.g. Artemis or another genome browser, you should add 1.
 
 ```
 > gemucator-run.py --mutation rpoB_S450L
@@ -63,7 +63,7 @@ AssertionError: x is not a nucleotide!
 ```
 Note that mutation->location->mutation is not uniquely defined for some 'promoters' i.e. the promoter for gene X may lie within the coding region of gene Y which makes assigning it as a CDS mutation or a PROM mutation difficult.
 
-Finally, it will parse insertions and deletions as long as they conform to the format like in the example below.
+it will parse insertions and deletions as long as they conform to the format like in the example below.
 
 ```
 > gemucator-run.py --mutation rpoB_1300_ins

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ AssertionError: x is not a nucleotide!
 ```
 Note that mutation->location->mutation is not uniquely defined for some 'promoters' i.e. the promoter for gene X may lie within the coding region of gene Y which makes assigning it as a CDS mutation or a PROM mutation difficult.
 
-it will parse insertions and deletions as long as they conform to the format like in the example below.
+It will also parse insertions and deletions as long as they conform to the format like in the example below.
 
 ```
 > gemucator-run.py --mutation rpoB_1300_ins
@@ -72,6 +72,13 @@ rpoB_1300_ins:
 ```
 
 This means an insertion (`ins`) of any length at nucleotide `1300` in the coding sequence of the `rpoB` gene. You can add the a positive integer to be specific about the number of bases inserted (e.g. `rpoB_1300_ins_2`) or you can be highly specific and state which bases are inserted (e.g. `rpoB_1300_ins_ac`). Likewise, for a deletion replace `ins` with `del`, although here it is superfluous to state which bases are deleted.
+
+Finally, you can get the amino acid changes (if any) associated with particular nucleotide substitutions.
+
+```
+> gemucator-run.py --nucleotide_substitution C761155T
+rpoB S450L
+```
 
 ## The gemucator class
 

--- a/bin/gemucator-run.py
+++ b/bin/gemucator-run.py
@@ -9,6 +9,7 @@ if __name__ == "__main__":
     parser.add_argument("--mutation",help="the full length mutation to locate on the genome e.g. rpoB_S450L")
     parser.add_argument("--nucleotide",action='store_true',help="overrides the logic and forces the code to treat this mutation as a simple nucleotide mutation. Useful for RNA genes.")
     parser.add_argument("--location",type=int,help="the genome position we want to find the gene for")
+    parser.add_argument("--nucleotide_substitution",help="Input is a nucleotide position and substitution, e.g. A779188C, output is either \'non-genic\' ot the resulting amino acid change (or lack thereof)")
     parser.add_argument("--promoter_length",type=int,default=100,help="the number of bases upstream of a gene that we will consider to form the promoter")
     parser.add_argument("--genbank_file",help="the path to the reference GenBank file we want to work with. If not specified, the code will load H37rV.gbk from its config/ folder.")
     options = parser.parse_args()
@@ -41,5 +42,13 @@ if __name__ == "__main__":
 
             print("Cannot find a gene or plausible promoter for location "+str(options.location))
 
+    elif options.nucleotide_substitution:
+        # no promoter length given as only interested in positions in CDS
+        gene, residue, position, alt_residue = reference_genome.interpret_substitution(options.nucleotide_substitution)
+        
+        if gene is not None:
+
+            print('%s %s%s%s' % (gene, residue, position, alt_residue))
+
     else:
-        raise Exception("Must specify one of --mutation or --location!")
+        raise Exception("Must specify one of --mutation or --location or --nucleotide_substitution!")

--- a/gemucator/core.py
+++ b/gemucator/core.py
@@ -537,7 +537,7 @@ class gemucator(object):
         
         assert alt_nucleotide in ['A', 'T', 'C', 'G'], "Last character of the nucleotide substitution is not a nucleotide"
         
-        assert int(nucleotide_substitution[1:-1]), "Nucleotide substituion has to be in the format A779188C"
+        assert int(nucleotide_substitution[1:-1]), "Nucleotide substituion has to be in the format C761155T"
 
         location = int(nucleotide_substitution[1:-1])
 
@@ -565,7 +565,7 @@ class gemucator(object):
         alt_genome.seq[location - 1] = alt_nucleotide
         # convet back to normal immutable seq, as otherwise translate method later doesnt work
         alt_genome.seq = alt_genome.seq.toseq()
-        print(alt_genome.seq[761154])
+        # print(alt_genome.seq[761154])
 
         # we need to get the sequence of the CDS which has a gene name or locus tag matching gene_name
         for record in self.genome.features:
@@ -603,13 +603,10 @@ class gemucator(object):
                             ref_protein = ref_coding_nucleotides.reverse_complement().seq.translate()
                             alt_protein = alt_coding_nucleotides.reverse_complement().seq.translate()
 
+        # just double check that residue is the same as the target position in the ref protein
         assert residue == ref_protein[position - 1] 
 
         return gene_name, residue, position, alt_protein[position - 1]
-        '''
-        for i, (r, a) in enumerate(zip(ref_protein, alt_protein)):
-            if r != a:
-                print(r + str(i + 1) + a)
-        '''
+
 
 

--- a/gemucator/core.py
+++ b/gemucator/core.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python
 
 import pkg_resources, re
-
 from Bio import SeqIO
+from Bio.Seq import Seq
+from copy import deepcopy
 
 class gemucator(object):
 
@@ -419,6 +420,7 @@ class gemucator(object):
             gene_name (str) the name of the name, if relevant, e.g. "katG"
             residue or base (str) e.g. "A" or "a"
             position (int)
+
         '''
 
         assert int(location)>0, "genomic position has to be a positive integer"
@@ -512,3 +514,102 @@ class gemucator(object):
                     return(gene_name,residue,position)
 
         return(None,None,None)
+
+    def interpret_substitution(self, nucleotide_substitution):
+        '''
+        What is what is the effect of the supplied nucleotide substitution in the genome defined by the genbank file? 
+
+        Args:
+            nucleotide_substitution (str) nucleotide position and substitution, e.g. A779188C
+
+        Returns:
+            gene_name (str) the name of the name, if relevant, e.g. "katG"
+            residue (str) amino acid residue in the reference genome
+            position (int) position of the amino acid in the protein
+            alt_residue (str) modified amino acid (or same amino acid if synonymous)
+        '''
+
+        reference_nucleotide = nucleotide_substitution[0]
+
+        alt_nucleotide = nucleotide_substitution[-1]
+
+        assert reference_nucleotide in ['A', 'T', 'C', 'G'], "First character of the nucleotide substitution is not a nucleotide"
+        
+        assert alt_nucleotide in ['A', 'T', 'C', 'G'], "Last character of the nucleotide substitution is not a nucleotide"
+        
+        assert int(nucleotide_substitution[1:-1]), "Nucleotide substituion has to be in the format A779188C"
+
+        location = int(nucleotide_substitution[1:-1])
+
+        # use existing code in self.identify_gene() to identify the relevant gene
+        # considered modifying that function to optionally return sequence, but this seemed like the lighter touch option, if more repetitive
+        # promoter_length set to 0 as dont care about promoter for this, since interested in CDS SNPs only
+        gene_name, residue, position = self.identify_gene(location, promoter_length = 0)
+
+        if gene_name is None:
+
+            print('%s is intergenic' % nucleotide_substitution)
+
+            return None, None, None, None
+
+        # since we are given the position of the mutation in context of the whole reference seq, 
+        # makes sense to just modify based on position in the whole sequence
+        # therefore, we first take a deepcopy (use deepcopy to prevent any confusion between the two pointers)
+        alt_genome = deepcopy(self.genome)
+
+        # check that ref position is as expected
+        assert alt_genome.seq[location - 1] == reference_nucleotide
+        # convert the alt_genome.seq to a mutable biopython seq http://www.csc.kth.se/utbildning/kth/kurser/DD2397/appbio09/docs/BioPython.pdf
+        alt_genome.seq = alt_genome.seq.tomutable()
+        # modify the sequence
+        alt_genome.seq[location - 1] = alt_nucleotide
+        # convet back to normal immutable seq, as otherwise translate method later doesnt work
+        alt_genome.seq = alt_genome.seq.toseq()
+        print(alt_genome.seq[761154])
+
+        # we need to get the sequence of the CDS which has a gene name or locus tag matching gene_name
+        for record in self.genome.features:
+
+            # check that the record is a Coding Sequence
+            if record.type in ['CDS','rRNA']:
+
+                start=record.location.start.position
+                end=record.location.end.position
+                strand=record.location.strand.real
+
+                if 'gene' in record.qualifiers.keys():
+
+                    if gene_name == record.qualifiers['gene'][0]:
+
+                        ref_coding_nucleotides=self.genome[start:end]
+                        alt_coding_nucleotides = alt_genome[start:end]
+                        if strand == 1:
+                            ref_protein = ref_coding_nucleotides.seq.translate()
+                            alt_protein = alt_coding_nucleotides.seq.translate()
+                        elif strand == -1:
+                            ref_protein = ref_coding_nucleotides.reverse_complement().seq.translate()
+                            alt_protein = alt_coding_nucleotides.reverse_complement().seq.translate()
+
+                elif 'locus_tag' in record.qualifiers.keys():
+
+                    if gene_name == record.qualifiers['locus_tag'][0]:
+
+                        ref_coding_nucleotides=self.genome[start:end]
+                        alt_coding_nucleotides = alt_genome[start:end]
+                        if strand == 1:
+                            ref_protein = ref_coding_nucleotides.seq.translate()
+                            alt_protein = alt_coding_nucleotides.seq.translate()
+                        elif strand == -1:
+                            ref_protein = ref_coding_nucleotides.reverse_complement().seq.translate()
+                            alt_protein = alt_coding_nucleotides.reverse_complement().seq.translate()
+
+        assert residue == ref_protein[position - 1] 
+
+        return gene_name, residue, position, alt_protein[position - 1]
+        '''
+        for i, (r, a) in enumerate(zip(ref_protein, alt_protein)):
+            if r != a:
+                print(r + str(i + 1) + a)
+        '''
+
+


### PR DESCRIPTION
Hi Phil,

I have a use case which is really close to existing gemucator functionality but not currently covered.

I want to take a nucleotide substitution, e.g. from a vcf, and see whether it impacts on the amino acid sequence of a protein. So, I modified gemucator to do this. Maybe you/others will find it useful as well? 

When I was developing it to look at A779188C and then I tested it with C761155T (which leads to rpoB S450L).

Full disclosure, I haven't done a lot of edge case checking (sorry!), and I won't be mortally offended if you don't accept the PR.

All the best,

Phil